### PR TITLE
get mode from config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "js-yaml": "3.13.1",
     "mkdirp": "0.5.1",
     "openpgp": "4.7.1",
+    "prompt-sync": "^4.2.0",
     "request": "2.88.0",
     "semver": "6.3.0",
     "split": "1.0.1",


### PR DESCRIPTION
With docopt, I did not find way to distinguish if the value of cli['--mode'] is supplied by user or it is the default value. That's why I have added the variable isModeSpecified for this purpose. Also as the default mode will be obtained from saved config file or entered by user, so I removed the [default: 
 dedicated ] the in help message.

