### PR TITLE
Bump saltstack version to 3006

### DIFF
--- a/remnux-cli.js
+++ b/remnux-cli.js
@@ -232,7 +232,7 @@ const saltCheckVersion = (path, value) => {
 
 const setupSalt = async () => {
   if (cli['--dev'] === false) {
-    const baseUrl = 'https://repo.saltproject.io/py3/ubuntu'
+    const baseUrl = 'https://repo.saltproject.io/salt/py3/ubuntu'
     const aptSourceList = '/etc/apt/sources.list.d/saltstack.list'
     const aptDebString = `deb [arch=amd64] ${baseUrl}/${osVersion}/amd64/${saltstackVersion} ${osCodename} main`
 
@@ -244,8 +244,9 @@ const setupSalt = async () => {
       console.log('NOTICE: Fixing incorrect Saltstack version configuration.')
       console.log('Installing and configuring Saltstack properly ...')
       await child_process.execAsync('apt-get remove -y --allow-change-held-packages salt-common salt-minion')
-      await fs.writeFileAsync(aptSourceList, `deb [arch=amd64] ${baseUrl}/${osVersion}/amd64/${saltstackVersion} ${osCodename} main`)
-      await child_process.execAsync(`wget -O - ${baseUrl}/${osVersion}/amd64/${saltstackVersion}/salt-archive-keyring.gpg | apt-key add -`)
+      await child_process.execAsync('mkdir /etc/apt/keyrings')
+      await child_process.execAsync(`curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring-2023.gpg https://repo.saltproject.io/salt/py3/ubuntu/20.04/amd64/SALT-PROJECT-GPG-PUBKEY-2023.gpg`)
+      await fs.writeFileAsync(aptSourceList, `deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch=amd64] ${baseUrl}/${osVersion}/amd64/${saltstackVersion} ${osCodename} main`)
       await child_process.execAsync('apt-get update')
       await child_process.execAsync('apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y --allow-change-held-packages salt-common', {
         env: {
@@ -255,8 +256,9 @@ const setupSalt = async () => {
       })
     } else if (aptExists === false || saltExists === false) {
       console.log('Installing and configuring SaltStack properly ...')
-      await fs.writeFileAsync(aptSourceList, `deb [arch=amd64] ${baseUrl}/${osVersion}/amd64/${saltstackVersion} ${osCodename} main`)
-      await child_process.execAsync(`wget -O - ${baseUrl}/${osVersion}/amd64/${saltstackVersion}/salt-archive-keyring.gpg | apt-key add -`)
+      await child_process.execAsync('mkdir /etc/apt/keyrings')
+      await child_process.execAsync(`curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring-2023.gpg https://repo.saltproject.io/salt/py3/ubuntu/20.04/amd64/SALT-PROJECT-GPG-PUBKEY-2023.gpg`)
+      await fs.writeFileAsync(aptSourceList, `deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch=amd64] ${baseUrl}/${osVersion}/amd64/${saltstackVersion} ${osCodename} main`)
       await child_process.execAsync('apt-get update')
       await child_process.execAsync('apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y --allow-change-held-packages salt-common', {
         env: {

--- a/remnux-cli.js
+++ b/remnux-cli.js
@@ -49,7 +49,7 @@ Options:
   --verbose             Display verbose logging
 `
 
-const saltstackVersion = '3004'
+const saltstackVersion = '3006'
 const pubKey = `
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG


### PR DESCRIPTION
Fixes incompatibility with `importlib_metadata` >= 5.0.0

https://github.com/saltstack/salt/issues/62851 

REMnux CLI output

```text
remnux@remnux:~$ remnux upgrade
> remnux-cli@1.3.4.2.g87c65ef
> remnux-version: v2023.26.1

> downloading v2023.31.1
>> downloading remnux-salt-states-v2023.31.1.tar.gz.asc
>> downloading remnux-salt-states-v2023.31.1.tar.gz.sha256
>> downloading remnux-salt-states-v2023.31.1.tar.gz.sha256.asc
>> downloading remnux-salt-states-v2023.31.1.tar.gz
> validating file remnux-salt-states-v2023.31.1.tar.gz
> validating signature for remnux-salt-states-v2023.31.1.tar.gz.sha256
> extracting update remnux-salt-states-v2023.31.1.tar.gz
> using previous mode: addon
> upgrading/updating to v2023.31.1
>> Log file: /var/cache/remnux/cli/v2023.31.1/saltstack.log

Update returned exit code not zero
Error: Update returned exit code not zero
    at ChildProcess.<anonymous> (/snapshot/remnux-cli/remnux-cli.js:569:23)
    at ChildProcess.emit (events.js:315:20)
    at maybeClose (internal/child_process.js:1021:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
```

saltstack.log

```text
/usr/bin/salt-call:6: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  from pkg_resources import load_entry_point
[DEBUG   ] Missing configuration file: /etc/salt/minion
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: remnux
[DEBUG   ] Using importlib_metadata to load entry points
[ERROR   ] 'EntryPoints' object has no attribute 'items'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/salt/utils/parsers.py", line 210, in parse_args
    mixin_after_parsed_func(self)
  File "/usr/lib/python3/dist-packages/salt/utils/parsers.py", line 887, in __setup_extended_logging
    log.setup_extended_logging(self.config)
  File "/usr/lib/python3/dist-packages/salt/log/setup.py", line 414, in setup_extended_logging
    providers = salt.loader.log_handlers(opts)
  File "/usr/lib/python3/dist-packages/salt/loader/__init__.py", line 686, in log_handlers
    _module_dirs(
  File "/usr/lib/python3/dist-packages/salt/loader/__init__.py", line 148, in _module_dirs
    for entry_point in entrypoints.iter_entry_points("salt.loader"):
  File "/usr/lib/python3/dist-packages/salt/utils/entrypoints.py", line 43, in _wrapped
    return f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/utils/entrypoints.py", line 62, in iter_entry_points
    for entry_point_group, entry_points_list in entry_points.items():
AttributeError: 'EntryPoints' object has no attribute 'items'
```